### PR TITLE
Update role_centric.sql

### DIFF
--- a/examples/policies/role_centric.sql
+++ b/examples/policies/role_centric.sql
@@ -44,7 +44,7 @@ with check (true);
 create policy "Members can read"
 on "public"."groups"
 as permissive
-for all
+for select
 to authenticated
 using (user_is_group_member(id));
 


### PR DESCRIPTION
The description states: Allow authenticated group members with any role to read groups

However, the permissive check is for all instead of just select.

closes #35 